### PR TITLE
pass in ViewModel to EntryItemQuery to make query & change recycler

### DIFF
--- a/app/src/main/java/com/example/fridgerec/fragments/InventoryFragment.java
+++ b/app/src/main/java/com/example/fridgerec/fragments/InventoryFragment.java
@@ -27,14 +27,13 @@ import com.example.fridgerec.activities.lithoSpecs.ListSection;
 import com.example.fridgerec.activities.lithoSpecs.ListSectionSpec;
 import com.example.fridgerec.interfaces.LithoUIChangeHandler;
 import com.example.fridgerec.model.EntryItem;
-import com.example.fridgerec.model.EntryItemList;
+import com.example.fridgerec.model.EntryItemQuery;
 import com.example.fridgerec.model.InventoryViewModel;
 import com.facebook.litho.Component;
 import com.facebook.litho.ComponentContext;
 import com.facebook.litho.LithoView;
 import com.facebook.litho.sections.SectionContext;
 import com.facebook.litho.sections.widget.RecyclerCollectionComponent;
-import com.facebook.litho.widget.Text;
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
 import com.parse.FindCallback;
 import com.parse.ParseException;
@@ -92,7 +91,7 @@ public class InventoryFragment extends Fragment implements LithoUIChangeHandler 
     
     setupObservers();
 
-    EntryItemList.queryEntryItems(model.getSortFilterParams().getValue(),
+    EntryItemQuery.queryEntryItems(model,
         EntryItem.CONTAINER_LIST_INVENTORY);
   }
 
@@ -103,10 +102,10 @@ public class InventoryFragment extends Fragment implements LithoUIChangeHandler 
   }
 
   private void observeSortFilterParams() {
-    final Observer<HashMap<EntryItemList.SortFilter, Object>> sortFilterParamsObserver = new Observer<HashMap<EntryItemList.SortFilter, Object>>() {
+    final Observer<HashMap<EntryItemQuery.SortFilter, Object>> sortFilterParamsObserver = new Observer<HashMap<EntryItemQuery.SortFilter, Object>>() {
       @Override
-      public void onChanged(HashMap<EntryItemList.SortFilter, Object> sortFilterObjectHashMap) {
-        EntryItemList.queryEntryItems(model.getSortFilterParams().getValue(),
+      public void onChanged(HashMap<EntryItemQuery.SortFilter, Object> sortFilterObjectHashMap) {
+        EntryItemQuery.queryEntryItems(model,
             EntryItem.CONTAINER_LIST_INVENTORY);
 
         Log.i(TAG, "sort & filter params changed");
@@ -119,24 +118,24 @@ public class InventoryFragment extends Fragment implements LithoUIChangeHandler 
     final Observer<List<EntryItem>> inventoryListObserver = new Observer<List<EntryItem>>() {
       @Override
       public void onChanged(List<EntryItem> entryItems) {
-        setupLithoRecycler(model.getInventoryList().getValue());
+        setupLithoRecycler(model.getList().getValue());
 
         Log.i(TAG, "inventory list changed");
       }
     };
 
-    model.getInventoryList().observe(getViewLifecycleOwner(), inventoryListObserver);
+    model.getList().observe(getViewLifecycleOwner(), inventoryListObserver);
 
     final Observer<HashMap<String, List<EntryItem>>> inventoryMapObserver = new Observer<HashMap<String, List<EntryItem>>>() {
       @Override
       public void onChanged(HashMap<String, List<EntryItem>> stringListHashMap) {
-        setupSectionedLithoRecycler(model.getInventoryMap().getValue());
+        setupSectionedLithoRecycler(model.getMap().getValue());
 
         Log.i(TAG, "inventory list changed (sort by food group)");
       }
     };
 
-    model.getInventoryMap().observe(getViewLifecycleOwner(), inventoryMapObserver);
+    model.getMap().observe(getViewLifecycleOwner(), inventoryMapObserver);
   }
 
   private void onClickFab() {

--- a/app/src/main/java/com/example/fridgerec/model/DatasetViewModel.java
+++ b/app/src/main/java/com/example/fridgerec/model/DatasetViewModel.java
@@ -1,0 +1,12 @@
+package com.example.fridgerec.model;
+
+import androidx.lifecycle.MutableLiveData;
+
+import java.util.HashMap;
+import java.util.List;
+
+public interface DatasetViewModel {
+  public MutableLiveData<HashMap<EntryItemQuery.SortFilter, Object>> getSortFilterParams();
+  public MutableLiveData<List<EntryItem>> getList();
+  public MutableLiveData<HashMap<String, List<EntryItem>>> getMap();
+}

--- a/app/src/main/java/com/example/fridgerec/model/InventoryViewModel.java
+++ b/app/src/main/java/com/example/fridgerec/model/InventoryViewModel.java
@@ -6,31 +6,31 @@ import androidx.lifecycle.ViewModel;
 import java.util.HashMap;
 import java.util.List;
 
-public class InventoryViewModel extends ViewModel {
+public class InventoryViewModel extends ViewModel implements DatasetViewModel {
   private MutableLiveData<Boolean> refresh;
   private MutableLiveData<List<EntryItem>> inventoryList;
   private MutableLiveData<HashMap<String, List<EntryItem>>> inventoryMap;
-  private MutableLiveData<HashMap<EntryItemList.SortFilter, Object>> sortFilterParams;
+  private MutableLiveData<HashMap<EntryItemQuery.SortFilter, Object>> sortFilterParams;
 
-  public MutableLiveData<HashMap<EntryItemList.SortFilter, Object>> getSortFilterParams() {
+  public MutableLiveData<HashMap<EntryItemQuery.SortFilter, Object>> getSortFilterParams() {
     if (sortFilterParams == null) {
       sortFilterParams = new MutableLiveData<>();
 
-      HashMap<EntryItemList.SortFilter, Object> map = new HashMap<>();
-      map.put(EntryItemList.SortFilter.NONE, null);
+      HashMap<EntryItemQuery.SortFilter, Object> map = new HashMap<>();
+      map.put(EntryItemQuery.SortFilter.NONE, null);
       sortFilterParams.setValue(map);
     }
     return sortFilterParams;
   }
 
-  public MutableLiveData<List<EntryItem>> getInventoryList() {
+  public MutableLiveData<List<EntryItem>> getList() {
     if (inventoryList == null) {
       inventoryList = new MutableLiveData<>();
     }
     return inventoryList;
   }
 
-  public MutableLiveData<HashMap<String, List<EntryItem>>> getInventoryMap() {
+  public MutableLiveData<HashMap<String, List<EntryItem>>> getMap() {
     if (inventoryMap == null) {
       inventoryMap = new MutableLiveData<>();
     }


### PR DESCRIPTION
summary:
- added interface DatasetViewModel to let EntryItemQuery access both inventory & shopping ViewModel methods in future to make queries for both Fragments
- generify get methods in ViewModel (generalise for both inventory & shopping)
- renamed EntryItemList to EntryItemQuery to reflect purpose of class as querier of EntryItem
- save viewmodel, query params, container list as fields in EntryItemQuery

test:
(default search param onViewCreated() is NONE, then programmatically change to SORT_FOOD_GROUP)
<img width="1543" alt="Screen Shot 2022-07-08 at 11 31 08 AM" src="https://user-images.githubusercontent.com/32890361/178050848-09d4a8f8-fc66-4a7e-b4e7-a600073c3f56.png">

