### PR TITLE
changed checkedItems from list to set faster operation time

### DIFF
--- a/app/src/main/java/com/example/fridgerec/interfaces/DatasetViewModel.java
+++ b/app/src/main/java/com/example/fridgerec/interfaces/DatasetViewModel.java
@@ -6,6 +6,7 @@ import com.example.fridgerec.model.EntryItem;
 import com.example.fridgerec.EntryItemQuery;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 
 public interface DatasetViewModel {
@@ -13,5 +14,6 @@ public interface DatasetViewModel {
   public MutableLiveData<List<EntryItem>> getList();
   public MutableLiveData<HashMap<String, List<EntryItem>>> getMap();
   public MutableLiveData<Boolean> getInDeleteMode();
-  public MutableLiveData<List<EntryItem>> getCheckedItems();
+  public List<EntryItem> getCheckedItemsList();
+  public HashSet<EntryItem> getCheckedItemsSet();
 }

--- a/app/src/main/java/com/example/fridgerec/model/viewmodel/InventoryViewModel.java
+++ b/app/src/main/java/com/example/fridgerec/model/viewmodel/InventoryViewModel.java
@@ -1,5 +1,7 @@
 package com.example.fridgerec.model.viewmodel;
 
+import android.util.Log;
+
 import androidx.lifecycle.MutableLiveData;
 import androidx.lifecycle.ViewModel;
 
@@ -9,16 +11,19 @@ import com.example.fridgerec.model.EntryItem;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 
 public class InventoryViewModel extends ViewModel implements DatasetViewModel {
+  public static final String TAG = "InventoryViewModel";
   private MutableLiveData<Boolean> refresh;
   private MutableLiveData<List<EntryItem>> inventoryList;
   private MutableLiveData<HashMap<String, List<EntryItem>>> inventoryMap;
   private MutableLiveData<HashMap<EntryItemQuery.SortFilter, Object>> sortFilterParams;
 
   private MutableLiveData<Boolean> inDeleteMode;
-  private MutableLiveData<List<EntryItem>> checkedItems;
+  private List<EntryItem> checkedItemsList;
+  private HashSet<EntryItem> checkedItemsSet;
 
   public MutableLiveData<HashMap<EntryItemQuery.SortFilter, Object>> getSortFilterParams() {
     if (sortFilterParams == null) {
@@ -55,11 +60,25 @@ public class InventoryViewModel extends ViewModel implements DatasetViewModel {
     return inDeleteMode;
   }
 
-  public MutableLiveData<List<EntryItem>> getCheckedItems() {
-    if (checkedItems == null) {
-      checkedItems = new MutableLiveData<>();
-      checkedItems.setValue(new ArrayList<>());
+  @Override
+  public List<EntryItem> getCheckedItemsList() {
+    if (checkedItemsList == null) {
+      checkedItemsList = new ArrayList<>();
     }
-    return checkedItems;
+    checkedItemsList.clear();
+    checkedItemsList.addAll(checkedItemsSet);
+
+    checkedItemsSet.clear();
+
+    Log.i(TAG, "checkedItemsList: " + checkedItemsList.toString()); //TODO: testing
+    return checkedItemsList;
+  }
+
+  @Override
+  public HashSet<EntryItem> getCheckedItemsSet() {
+    if (checkedItemsSet == null) {
+      checkedItemsSet = new HashSet<>();
+    }
+    return checkedItemsSet;
   }
 }


### PR DESCRIPTION
summary:
- onClick in ListItem, entryItem is added/removed from checkedItemsSet (remove operation is O(1) in Set & O(N) in List)
- convert to list when make query to delete checkedItems => checkedItemsList is accessed once in a long click delete flow => checkedItemsList should clear HashSet for later use
- checkedItemsList and checkedItemsSet doesn't need to be observed => not LiveData

test:
N/A