### PR TITLE
added check same item & check same content funcs in DataDiffSections

### DIFF
--- a/app/src/main/java/com/example/fridgerec/lithoSpecs/ListSectionSpec.java
+++ b/app/src/main/java/com/example/fridgerec/lithoSpecs/ListSectionSpec.java
@@ -11,6 +11,8 @@ import com.facebook.litho.sections.SectionContext;
 import com.facebook.litho.sections.annotations.GroupSectionSpec;
 import com.facebook.litho.sections.annotations.OnCreateChildren;
 import com.facebook.litho.sections.common.DataDiffSection;
+import com.facebook.litho.sections.common.OnCheckIsSameContentEvent;
+import com.facebook.litho.sections.common.OnCheckIsSameItemEvent;
 import com.facebook.litho.sections.common.RenderEvent;
 import com.facebook.litho.sections.common.SingleComponentSection;
 import com.facebook.litho.widget.ComponentRenderInfo;
@@ -33,6 +35,8 @@ public class ListSectionSpec {
 
     DataDiffSection.Builder<EntryItem> entryItem = DataDiffSection.<EntryItem>create(c)
         .data(entryItems)
+        .onCheckIsSameItemEventHandler(ListSection.onCheckIsSameItem(c))
+        .onCheckIsSameContentEventHandler(ListSection.onCheckIsSameContent(c))
         .renderEventHandler(ListSection.onRender(c));
 
     switch (foodCategoryHeaderTitle)
@@ -55,6 +59,22 @@ public class ListSectionSpec {
             .child(entryItem)
             .build();
     }
+  }
+
+  @OnEvent(OnCheckIsSameItemEvent.class)
+  public static boolean onCheckIsSameItem(
+      SectionContext c,
+      @FromEvent EntryItem previousItem,
+      @FromEvent EntryItem nextItem) {
+    return previousItem.getObjectId().equals(nextItem.getObjectId());
+  }
+
+  @OnEvent(OnCheckIsSameContentEvent.class)
+  public static boolean onCheckIsSameContent(
+      SectionContext c,
+      @FromEvent EntryItem previousItem,
+      @FromEvent EntryItem nextItem) {
+    return EntryItem.compareContent(previousItem, nextItem);
   }
 
   @OnEvent(RenderEvent.class)


### PR DESCRIPTION
summary:
- onCheckIsSameContent & Item funcs => no need rerender cells when new list passed to litho recycler

test:
note: the cells jump around instead of being rerendered
![Kapture 2022-07-12 at 15 19 56](https://user-images.githubusercontent.com/32890361/178605568-f60705e2-4680-4a01-b43c-8b4e105acd58.gif)

