### PR TITLE
change sort filter map key to chip resource id instead of chip label

### DIFF
--- a/app/src/main/java/com/example/fridgerec/dialogs/SortFilterParamsDialog.java
+++ b/app/src/main/java/com/example/fridgerec/dialogs/SortFilterParamsDialog.java
@@ -37,8 +37,8 @@ import java.util.HashMap;
 public class SortFilterParamsDialog extends DialogFragment{
   public static final String TAG = "SortFilterPrefDialog";
 
-  private HashMap<String, EntryItemQuery.SortFilter> sortChipParamMap;
-  private HashMap<String, EntryItemQuery.SortFilter> filterChipParamMap;
+  private HashMap<Integer, EntryItemQuery.SortFilter> sortChipParamMap;
+  private HashMap<Integer, EntryItemQuery.SortFilter> filterChipParamMap;
 
   private DialogSortFilterParamsBinding binding;
   private NavController navController;
@@ -156,13 +156,11 @@ public class SortFilterParamsDialog extends DialogFragment{
     HashMap<EntryItemQuery.SortFilter, Object> sortFilterParams = new HashMap<>();
 
     for (Integer id : binding.cgSort.getCheckedChipIds()) {
-      String chipLabel = ((Chip) binding.cgSort.findViewById(id)).getText().toString();
-      sortFilterParams.put(sortChipParamMap.get(chipLabel), null);
+      sortFilterParams.put(sortChipParamMap.get(id), null);
     }
 
     for (Integer id : binding.cgFilter.getCheckedChipIds()) {
-      String chipLabel = ((Chip) binding.cgFilter.findViewById(id)).getText().toString();
-      EntryItemQuery.SortFilter sortFilterParam = filterChipParamMap.get(chipLabel);
+      EntryItemQuery.SortFilter sortFilterParam = filterChipParamMap.get(id);
 
       Object val = null;
       switch (sortFilterParam) {
@@ -203,16 +201,16 @@ public class SortFilterParamsDialog extends DialogFragment{
 
   private void configChipMaps() {
     sortChipParamMap = new HashMap<>();
-    sortChipParamMap.put(getResources().getString(R.string.chip_food_name), EntryItemQuery.SortFilter.SORT_FOOD_NAME);
-    sortChipParamMap.put(getResources().getString(R.string.chip_food_group), EntryItemQuery.SortFilter.SORT_FOOD_GROUP);
-    sortChipParamMap.put(getResources().getString(R.string.chip_source_date), EntryItemQuery.SortFilter.SORT_SOURCE_DATE);
-    sortChipParamMap.put(getResources().getString(R.string.chip_expire_date), EntryItemQuery.SortFilter.SORT_EXPIRE_DATE);
+    sortChipParamMap.put(R.id.cSortFoodName, EntryItemQuery.SortFilter.SORT_FOOD_NAME);
+    sortChipParamMap.put(R.id.cSortFoodGroup, EntryItemQuery.SortFilter.SORT_FOOD_GROUP);
+    sortChipParamMap.put(R.id.cSortSourceDate, EntryItemQuery.SortFilter.SORT_SOURCE_DATE);
+    sortChipParamMap.put(R.id.cSortExpireDate, EntryItemQuery.SortFilter.SORT_EXPIRE_DATE);
 
     filterChipParamMap = new HashMap<>();
-    filterChipParamMap.put(getResources().getString(R.string.chip_expire_before), EntryItemQuery.SortFilter.FILTER_EXPIRE_BEFORE);
-    filterChipParamMap.put(getResources().getString(R.string.chip_expire_after), EntryItemQuery.SortFilter.FILTER_EXPIRE_AFTER);
-    filterChipParamMap.put(getResources().getString(R.string.chip_sourced_before), EntryItemQuery.SortFilter.FILTER_SOURCED_BEFORE);
-    filterChipParamMap.put(getResources().getString(R.string.chip_sourced_after), EntryItemQuery.SortFilter.FILTER_SOURCED_AFTER);
-    filterChipParamMap.put(getResources().getString(R.string.chip_food_group), EntryItemQuery.SortFilter.FILTER_FOOD_GROUP);
+    filterChipParamMap.put(R.id.cFilterExpireBefore, EntryItemQuery.SortFilter.FILTER_EXPIRE_BEFORE);
+    filterChipParamMap.put(R.id.cFilterExpireAfter, EntryItemQuery.SortFilter.FILTER_EXPIRE_AFTER);
+    filterChipParamMap.put(R.id.cFilterSourceBefore, EntryItemQuery.SortFilter.FILTER_SOURCED_BEFORE);
+    filterChipParamMap.put(R.id.cFilterSourceAfter, EntryItemQuery.SortFilter.FILTER_SOURCED_AFTER);
+    filterChipParamMap.put(R.id.cFilterFoodGroup, EntryItemQuery.SortFilter.FILTER_FOOD_GROUP);
   }
 }


### PR DESCRIPTION
summary:
- matching sortFilterParam enum to chip resource id is more reliable than chip label

test: 
sorting & filtering still detected