### PR TITLE
save edited item & refresh recycler on save

### DIFF
--- a/app/src/main/java/com/example/fridgerec/fragments/InventoryCreationFragment.java
+++ b/app/src/main/java/com/example/fridgerec/fragments/InventoryCreationFragment.java
@@ -68,16 +68,16 @@ public class InventoryCreationFragment extends Fragment {
 
     model = new ViewModelProvider(requireActivity()).get(InventoryViewModel.class);
 
+    if (Boolean.TRUE.equals(model.getInEditMode().getValue())) {
+      populateEntryItemDetail(model.getSelectedEntryItem());
+    }
+
     setupToolbar();
     configExposedDropdownMenu(binding.actvFoodGroup, getResources().getStringArray(R.array.foodGroupStrings));
     configExposedDropdownMenu(binding.actvAmountUnit, getResources().getStringArray(R.array.amountUnitStrings));
     onClickDatePickerBtn(binding.btnSourceDate);
     onClickDatePickerBtn(binding.btnExpireDate);
     onClickToolbarItem();
-
-    if (Boolean.TRUE.equals(model.getInEditMode().getValue())) {
-      populateEntryItemDetail(model.getSelectedEntryItem());
-    }
   }
 
   private void populateEntryItemDetail(EntryItem entryItem) {
@@ -145,6 +145,7 @@ public class InventoryCreationFragment extends Fragment {
               public void onChanged(Boolean success) {
                 if (success) {
                   Toast.makeText(getContext(), "item saved successfully", Toast.LENGTH_SHORT).show();
+                  model.getInEditMode().setValue(false);
                   navController.navigate(R.id.action_inventoryCreationFragment_to_inventoryFragment);
                 } else {
                   Toast.makeText(getContext(), "error: item saved unsuccessfully: " + model.getParseException(), Toast.LENGTH_SHORT).show();
@@ -164,7 +165,13 @@ public class InventoryCreationFragment extends Fragment {
   }
 
   private EntryItem extractData() {
-    EntryItem entryItem = new EntryItem();
+    EntryItem entryItem;
+    if (Boolean.TRUE.equals(model.getInEditMode().getValue())) {
+      entryItem = model.getSelectedEntryItem();
+    } else {
+      entryItem = new EntryItem();
+    }
+
     Food food = new Food();
     //TODO: save set food apiId upone autocomplete selection
 


### PR DESCRIPTION
summary:
- extractData(): initialise new EntryItem instance if inEditMode=false, else change existing entryItem instance
- set inEditMode=false on save success
- move populateEntryItemDetail() above UI configurations => otherwise exposed dropdown menu options will not be present

test:
![Kapture 2022-07-15 at 16 40 28](https://user-images.githubusercontent.com/32890361/179324969-a7873d9b-06c9-4b02-8af1-e14f68263f32.gif)

