### PR TITLE
queryEntryItems() take viewModel only & extract container list from v…

### DIFF
--- a/app/src/main/java/com/example/fridgerec/EntryItemQuery.java
+++ b/app/src/main/java/com/example/fridgerec/EntryItemQuery.java
@@ -38,9 +38,9 @@ public class EntryItemQuery {
   private static String containerList;
   private static DatasetViewModel viewModel;
 
-  public static void queryEntryItems(DatasetViewModel vm, String cl) {
+  public static void queryEntryItems(DatasetViewModel vm) {
     viewModel = vm;
-    containerList = cl;
+    containerList = vm.getContainerList();
     sortFilterParams = vm.getSortFilterParams().getValue();
 
     makeQuery(configParseQuery());

--- a/app/src/main/java/com/example/fridgerec/model/viewmodel/InventoryViewModel.java
+++ b/app/src/main/java/com/example/fridgerec/model/viewmodel/InventoryViewModel.java
@@ -97,8 +97,7 @@ public class InventoryViewModel extends ViewModel implements DatasetViewModel {
 
   public void refreshDataset() {
     Log.i(TAG, "refreshing inventory dataset");
-    EntryItemQuery.queryEntryItems(this,
-        EntryItem.CONTAINER_LIST_INVENTORY);
+    EntryItemQuery.queryEntryItems(this);
   }
 
   public void setSelectedEntryItem(EntryItem e) {


### PR DESCRIPTION
summary:
- for code quality
- extract container list from viewmodel => defensive programming: less chance of error (copy & pasting & forgetting to change arg)