### PR TITLE
implement transfer checked shopping items to inventory

### DIFF
--- a/app/src/main/java/com/example/fridgerec/fragments/InventoryFragment.java
+++ b/app/src/main/java/com/example/fridgerec/fragments/InventoryFragment.java
@@ -5,6 +5,7 @@ import android.os.Bundle;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
+import androidx.lifecycle.Observer;
 import androidx.lifecycle.ViewModelProvider;
 
 import android.view.ActionMode;
@@ -18,6 +19,7 @@ import com.example.fridgerec.R;
 import com.example.fridgerec.databinding.FragmentInventoryBinding;
 import com.example.fridgerec.fragments.basefragments.ListBaseFragment;
 import com.example.fridgerec.model.viewmodel.InventoryViewModel;
+import com.example.fridgerec.model.viewmodel.ShoppingViewModel;
 
 /**
  * A simple {@link Fragment} subclass.
@@ -26,6 +28,7 @@ import com.example.fridgerec.model.viewmodel.InventoryViewModel;
  */
 public class InventoryFragment extends ListBaseFragment {
   public static final String TAG = "InventoryFragment";
+  private ShoppingViewModel shoppingViewModel;
   private FragmentInventoryBinding binding;
 
   public InventoryFragment() {
@@ -42,13 +45,27 @@ public class InventoryFragment extends ListBaseFragment {
   public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
     super.onViewCreated(view, savedInstanceState);
     setupBaseFragment(new ViewModelProvider(requireActivity()).get(InventoryViewModel.class), view);
+    shoppingViewModel = new ViewModelProvider(requireActivity()).get(ShoppingViewModel.class);
     model.enterReadMode();
 
     onClickFab(binding.fab);
     setupToolbar(binding.toolbar);
     setupObservers(binding.lvInventoryList);
+    observeShoppingInDeleteMode();
 
     model.refreshDataset();
+  }
+
+  private void observeShoppingInDeleteMode() {
+    final Observer<Boolean> inDeleteModeObserver = new Observer<Boolean>() {
+      @Override
+      public void onChanged(Boolean inDeleteMode) {
+        if (!inDeleteMode) {
+          model.refreshDataset();
+        }
+      }
+    };
+    shoppingViewModel.getInDeleteMode().observe(getViewLifecycleOwner(), inDeleteModeObserver);
   }
 
   protected boolean onContextualMenuItemClicked(ActionMode mode, MenuItem item) {
@@ -66,10 +83,5 @@ public class InventoryFragment extends ListBaseFragment {
   @Override
   protected void navigateToCreation() {
     navController.navigate(R.id.action_inventoryFragment_to_inventoryCreationFragment);
-  }
-
-  @Override
-  protected void onDeleteModeEnd() {
-    model.refreshDataset();
   }
 }

--- a/app/src/main/java/com/example/fridgerec/fragments/ShoppingFragment.java
+++ b/app/src/main/java/com/example/fridgerec/fragments/ShoppingFragment.java
@@ -17,6 +17,7 @@ import android.widget.Toast;
 import com.example.fridgerec.R;
 import com.example.fridgerec.databinding.FragmentShoppingBinding;
 import com.example.fridgerec.fragments.basefragments.ListBaseFragment;
+import com.example.fridgerec.model.viewmodel.InventoryViewModel;
 import com.example.fridgerec.model.viewmodel.ShoppingViewModel;
 
 /**
@@ -54,6 +55,9 @@ public class ShoppingFragment extends ListBaseFragment {
   protected boolean onContextualMenuItemClicked(ActionMode mode, MenuItem item) {
     switch (item.getItemId()) {
       case R.id.mi_check:
+        Toast.makeText(getContext(),"transferring " + model.getCheckedItemsSet().size() + " item(s) to inventory", Toast.LENGTH_LONG).show();
+        ((ShoppingViewModel) model).transferCheckedItemsToInventory();
+        mode.finish();
         // TODO: implement
         return true;
       case R.id.mi_delete:
@@ -68,11 +72,5 @@ public class ShoppingFragment extends ListBaseFragment {
   @Override
   protected void navigateToCreation() {
     navController.navigate(R.id.action_shoppingFragment_to_shoppingCreationFragment);
-  }
-
-  @Override
-  protected void onDeleteModeEnd() {
-    model.refreshDataset();
-    inventoryViewModel.refreshDataset();
   }
 }

--- a/app/src/main/java/com/example/fridgerec/fragments/basefragments/ListBaseFragment.java
+++ b/app/src/main/java/com/example/fridgerec/fragments/basefragments/ListBaseFragment.java
@@ -39,7 +39,6 @@ public abstract class ListBaseFragment extends Fragment {
 
   protected abstract boolean onContextualMenuItemClicked(ActionMode mode, MenuItem item);
   protected abstract void navigateToCreation();
-  protected abstract void onDeleteModeEnd();
 
   protected void setupBaseFragment(DatasetViewModel viewModel, View view) {
     this.model = viewModel;
@@ -82,7 +81,7 @@ public abstract class ListBaseFragment extends Fragment {
         if (inDeleteMode) {
           fragmentView.startActionMode(configContextualMenuCallback());
         } else {
-          onDeleteModeEnd();
+          model.refreshDataset();
           //TODO: success or failed delete;
         }
       }

--- a/app/src/main/java/com/example/fridgerec/model/viewmodel/ShoppingViewModel.java
+++ b/app/src/main/java/com/example/fridgerec/model/viewmodel/ShoppingViewModel.java
@@ -148,4 +148,8 @@ public class ShoppingViewModel extends ViewModel implements DatasetViewModel {
     getInEditMode().setValue(false);
     getInDeleteMode().setValue(false);
   }
+
+  public void transferCheckedItemsToInventory() {
+    EntryItemQuery.transferToInventory(this);
+  }
 }


### PR DESCRIPTION
summary:
- no need fragment based ondelete
- onclick "check" in contextual menu, call transferToInventory()
- EntryItemQuery transferToInventory()
  - change containerList in each checked item & add source date as today
  - save in background
- InventoryFragment observes ShoppingViewModel inDeleteMode=false => refresh self (somehow not necessary)

- [add] change saveEntryItem() placement: save EntryItem after new Food is saved

test:
![Kapture 2022-07-18 at 17 16 57](https://user-images.githubusercontent.com/32890361/179638365-615d9f31-16e8-4854-9fc7-a316d1edeae5.gif)

