### PR TITLE
query Spoonacular autocomplete endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@
 .externalNativeBuild
 .cxx
 local.properties
+secret.xml
+/app/src/main/res/values/secret.xml

--- a/app/src/main/java/com/example/fridgerec/SpoonacularClient.java
+++ b/app/src/main/java/com/example/fridgerec/SpoonacularClient.java
@@ -2,10 +2,13 @@ package com.example.fridgerec;
 
 import android.content.Context;
 import android.util.Log;
+import android.widget.AutoCompleteTextView;
 
 import com.codepath.asynchttpclient.AsyncHttpClient;
 import com.codepath.asynchttpclient.RequestParams;
 import com.codepath.asynchttpclient.callback.JsonHttpResponseHandler;
+
+import org.json.JSONArray;
 
 import okhttp3.Headers;
 
@@ -14,27 +17,37 @@ public class SpoonacularClient {
   public static final String BASE_PATH = "https://api.spoonacular.com";
 
 
-  public static void setAutocompleteAdapter(Context context, String query) {
+  public static void setAutocompleteAdapter(Context context, String query, AutoCompleteTextView actv) {
     String autocompleteEndptPath = "/food/ingredients/autocomplete";
 
     AsyncHttpClient client = new AsyncHttpClient();
-    RequestParams params = new RequestParams();
-    params.put("apiKey", context.getString(R.string.spoonacular_api_key));
+    RequestParams params = getRequestParamsObj(context);
     params.put("query", query);
     params.put("metaInformation", true);
 
-    client.get(BASE_PATH + autocompleteEndptPath, new JsonHttpResponseHandler() {
+    // + "?apiKey=" + context.getString(R.string.spoonacular_api_key)
+    client.get(BASE_PATH + autocompleteEndptPath, params, new JsonHttpResponseHandler() {
       @Override
       public void onSuccess(int statusCode, Headers headers, JSON json) {
         Log.i(TAG, "[autocomplete query onSuccess]");
+
+        JSONArray suggestions = json.jsonArray;
+        Log.i(TAG, "results" + suggestions.toString()); //testing
+
         // TODO: extract food objects from result
         // TODO: attach new adapter
       }
 
       @Override
       public void onFailure(int statusCode, Headers headers, String response, Throwable throwable) {
-        Log.e(TAG, String.format("[autocomplete query onFailure] status code: %d | response: %s", statusCode, response));
+        Log.e(TAG, String.format("[autocomplete query onFailure] status code: %d | throwable: %s", statusCode, throwable));
       }
     });
+  }
+
+  private static RequestParams getRequestParamsObj(Context context) {
+    RequestParams params = new RequestParams();
+    params.put("apiKey", context.getString(R.string.spoonacular_api_key));
+    return params;
   }
 }


### PR DESCRIPTION
summary: 
- add params to asynchttpclient

test:
expected result: list of result for query="apple" should show up in log
<img width="1138" alt="Screen Shot 2022-07-21 at 5 14 51 PM" src="https://user-images.githubusercontent.com/32890361/180336853-76f2d343-352c-4528-9fd4-0e69a73f7fb3.png">

