### PR TITLE
implemented cancel notification

### DIFF
--- a/app/src/main/java/com/example/fridgerec/model/viewmodel/SettingsViewModel.java
+++ b/app/src/main/java/com/example/fridgerec/model/viewmodel/SettingsViewModel.java
@@ -53,25 +53,34 @@ public class SettingsViewModel extends ViewModel implements ParseCallback {
   }
 
   public void setRecurringReminder(Context context) {
-    Calendar notificationTime = Calendar.getInstance();
-    notificationTime.setTimeZone(TimeZone.getDefault());
-    notificationTime.set(Calendar.HOUR_OF_DAY, getUserSettings().getNotificationHour());
-    notificationTime.set(Calendar.MINUTE, getUserSettings().getNotificationMinute());
-
-    Intent consumptionReminder = new Intent(context, ReminderReceiver.class);
-    consumptionReminder.putExtra(Settings.KEY_NOTIFICATION_EXPIRE_DATE_OFFSET, getUserSettings().getNotificationExpireDateOffset());
-    consumptionReminder.putExtra(Settings.KEY_NOTIFICATION_SOURCE_DATE_OFFSET, getUserSettings().getNotificationSourceDateOffset());
-
-    PendingIntent recurringConsumptionReminder = PendingIntent.getBroadcast(context, ReminderReceiver.REMINDER_NOTIFICATION_ID, consumptionReminder, PendingIntent.FLAG_MUTABLE | PendingIntent.FLAG_CANCEL_CURRENT);
     AlarmManager alarmManager = (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);
-    alarmManager.setInexactRepeating(AlarmManager.RTC, notificationTime.getTimeInMillis(), AlarmManager.INTERVAL_DAY, recurringConsumptionReminder);
+    alarmManager.setInexactRepeating(AlarmManager.RTC, getNotificationTimeInMillis(), AlarmManager.INTERVAL_DAY, getReminderPendingIntent(context));
 
     Toast.makeText(context, "food consumption reminder set", Toast.LENGTH_SHORT).show();
   }
 
   public void cancelRecurringReminder(Context context) {
+    AlarmManager alarmManager = (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);
+    alarmManager.cancel(getReminderPendingIntent(context));
 
-    //TODO cancel reminder here
     Toast.makeText(context, "food consumption reminder cancelled", Toast.LENGTH_SHORT).show();
+  }
+
+  private PendingIntent getReminderPendingIntent(Context context) {
+    Intent consumptionReminder = new Intent(context, ReminderReceiver.class);
+    consumptionReminder.putExtra(Settings.KEY_NOTIFICATION_EXPIRE_DATE_OFFSET, getUserSettings().getNotificationExpireDateOffset());
+    consumptionReminder.putExtra(Settings.KEY_NOTIFICATION_SOURCE_DATE_OFFSET, getUserSettings().getNotificationSourceDateOffset());
+
+    PendingIntent recurringConsumptionReminder = PendingIntent.getBroadcast(context, ReminderReceiver.REMINDER_NOTIFICATION_ID, consumptionReminder, PendingIntent.FLAG_MUTABLE | PendingIntent.FLAG_CANCEL_CURRENT);
+    return recurringConsumptionReminder;
+  }
+
+  private long getNotificationTimeInMillis() {
+    Calendar notificationTime = Calendar.getInstance();
+    notificationTime.setTimeZone(TimeZone.getDefault());
+    notificationTime.set(Calendar.HOUR_OF_DAY, getUserSettings().getNotificationHour());
+    notificationTime.set(Calendar.MINUTE, getUserSettings().getNotificationMinute());
+
+    return notificationTime.getTimeInMillis();
   }
 }


### PR DESCRIPTION
summary:
- refactor/extract set notification time
- refactor/extract pending intent creation => so get same PendingIntent for scheduling & cancelling
- cancel notification by passing in same intent

test:
note: notification scheduled for 3:20 => immediately disable notification => notification not delivered even at 3:22

<img width="341" alt="Screen Shot 2022-07-27 at 11 28 44 AM" src="https://user-images.githubusercontent.com/32890361/181346637-27a825c8-2552-4fc1-be2a-17816adc4ebf.png">
<img width="361" alt="Screen Shot 2022-07-27 at 11 28 50 AM" src="https://user-images.githubusercontent.com/32890361/181346641-850931be-ee2c-444b-8e8f-d36c688428c5.png">
<img width="363" alt="Screen Shot 2022-07-27 at 11 28 56 AM" src="https://user-images.githubusercontent.com/32890361/181346648-655616a4-264b-4754-a22d-6160da3b9cbd.png">

