### PR TITLE
check notification enabled & animate on background UI thread

### DIFF
--- a/app/src/main/java/com/example/fridgerec/fragments/SettingsFragment.java
+++ b/app/src/main/java/com/example/fridgerec/fragments/SettingsFragment.java
@@ -57,16 +57,28 @@ public class SettingsFragment extends Fragment {
 
     setupToolbar();
     reminderEnabledSwitchCheckListener();
-    checkReminderEnabled();
     onClickTimePickerBtn(binding.btnTimePicker);
     onClickSaveReminderSettingsBtn(binding.btnSaveReminderSettings);
     onClickLogoutBtn(binding.btnLogout);
+    checkReminderEnabled();
   }
 
   private void checkReminderEnabled() {
-    if (model.getUserSettings().getNotificationEnabled()) {
-      binding.swReminderEnabled.setChecked(true);
-    }
+    Runnable populateUI = new Runnable() {
+      @Override
+      public void run() {
+        getActivity().runOnUiThread(new Runnable() {
+          @Override
+          public void run() {
+            if (model.getUserSettings().getNotificationEnabled()) {
+              binding.swReminderEnabled.setChecked(true);
+            }
+          }
+        });
+      }
+    };
+    Thread populateUIThread = new Thread(populateUI);
+    populateUIThread.start();
   }
 
   private void reminderEnabledSwitchCheckListener() {


### PR DESCRIPTION
summary:
- if querying for user setting takes a while, won't block UI => more responsive
- run on UI thread: animation required if notification check enabled

test:
![Kapture 2022-07-28 at 11 26 43](https://user-images.githubusercontent.com/32890361/181611532-917dca51-78ed-4a6c-bff9-ae7faa77d673.gif)

